### PR TITLE
Ci/content sharing configuration snap

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -1,0 +1,45 @@
+name: snap
+on:
+  schedule:
+    - cron: '0 0 1 * *'
+  push:
+    branches:
+      - howto/content_sharing_configuration_snap
+  pull_request:
+    branches:
+      - howto/content_sharing_configuration_snap
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      application-snap-file: ${{ steps.build-application-snap.outputs.snap }}
+      configuration-snap-file: ${{ steps.build-configuration-snap.outputs.snap }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build application snap
+      uses: snapcore/action-build@v1
+      id: build-application-snap
+      with:
+        path: application_snap
+    - name: Build configuration snap
+      uses: snapcore/action-build@v1
+      id: build-configuration-snap
+      with:
+        path: configuration_snap
+    # Make sure the application snap is installable
+    - name: Install and connect the snaps
+      run: |
+        sudo snap install ${{ steps.build-application-snap.outputs.snap }} --dangerous
+        sudo snap install ${{ steps.build-configuration-snap.outputs.snap }} --dangerous
+        sudo snap connect my-ros2-teleop-test:configuration my-configuration-snap:configuration
+    # Do some testing with the snap
+    - name: Testing
+      run: |
+        snap info my-ros2-teleop-test
+        snap info my-configuration-snap
+    - uses: actions/upload-artifact@v3
+      with:
+        name: configuration-and-application-snaps
+        path: .

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -1,7 +1,5 @@
 name: snap
 on:
-  schedule:
-    - cron: '0 0 1 * *'
   push:
     branches:
       - howto/content_sharing_configuration_snap
@@ -9,6 +7,7 @@ on:
     branches:
       - howto/content_sharing_configuration_snap
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   build:
@@ -18,6 +17,8 @@ jobs:
       configuration-snap-file: ${{ steps.build-configuration-snap.outputs.snap }}
     steps:
     - uses: actions/checkout@v4
+      with:
+        ref: howto/content_sharing_configuration_snap
     - name: Build application snap
       uses: snapcore/action-build@v1
       id: build-application-snap

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# snap configuration
+
+When a robotics application is snapped, one might want to use it on multiple different robots.
+Reusing the same snap means that we must be able to configure the snap to the specificity of a robot once installed on it.
+
+This repository is hosting examples of the ROS snap configuration how-to-guides from the [ubuntu.com/robotics/docs](ubuntu.com/robotics/docs).
+
+Please refer the [main README.md](https://github.com/ubuntu-robotics/snap_configuration/blob/main/README.md) for more information.


### PR DESCRIPTION
Reusable CI. We don't use the default one since we have two snaps and need some connection test.